### PR TITLE
Fix sound problem

### DIFF
--- a/Bolt.cs
+++ b/Bolt.cs
@@ -29,6 +29,7 @@ namespace BSFDTestbed
             {
                 StartCoroutine(Delay(delayTime));
                 BSFDinteraction.audioBoltScrew.Play();
+                BSFDinteraction.audioBoltScrew.gameObject.transform.position = transform.position;
                 currentBoltStep += down ? -1 : 1;
                 transform.rotation = Quaternion.Euler(transform.rotation.eulerAngles + new Vector3(0, 0, down ? -45 : 45));
                 transform.localPosition += new Vector3(0, down ? boltMoveAmount : -boltMoveAmount, 0);


### PR DESCRIPTION
When you got far away from this MasterAudio sound gameobject, the bolt sound got quieter. This is because the sound position was not being updated. This is how playmaker oneshots work. The position needs set. Also solves problem of certain bolts causing weird bias in left/right ear.

(Check line 32)